### PR TITLE
[FIX] Missing ":" in filter.exclude.directories section

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -36,7 +36,7 @@ For directories, list them by **key**. Optionally, you can specify a prefix or s
                                 prefix: 'API'
                     exclude:
                         directories:
-                            'tests/data' ~
+                            'tests/data': ~
 
 For files, list them by **name**:
 


### PR DESCRIPTION
Error :
Invalid type for path "testwork.code_coverage.filter.exclude.directories". Expected "array", but got "string"