### PR TITLE
fix a bug: when pcov is available and xdebug not available, the extension didn't work at all.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased] - 2023-xx-xx
 
+## [5.3.1] - 2023-05-08
+### Fixed
+ - `branchAndPathCoverage` configuration parameter is now correctly passed through to `initCodeCoverage` method. Before it was just ignored.
+
 ## [5.3.0] - 2023-02-04
 ### Added
 - Compatibility with `phpunit/php-code-coverage` v10.

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -208,7 +208,7 @@ class Extension implements ExtensionInterface
 
         $canCollectCodeCoverage = true;
         try {
-            $this->initCodeCoverage(new Filter(), $filterConfig, null, $cacheDir, $output);
+            $this->initCodeCoverage(new Filter(), $filterConfig, $branchPathConfig, $cacheDir, $output);
 
             $codeCoverageDefinition = $container->getDefinition(CodeCoverage::class);
             $filterDefinition = $container->getDefinition(Filter::class);


### PR DESCRIPTION
Hello, 

This PR is fixing the following issue:
If `xdebug` is off and `pcov` is on, the extension exited with an error `No code coverage driver is available. `. The reason for this bug was the fact that it always thought that `branchAndPathCoverage` is ON. In turn, it happened because the parameter was ignored and never passed down to the `initCodeCoverage` method.

Therefore, it worked only under `xdebug`, but never under `pcov` when `xdebug` is off.
To make it work, one needs to set `branchAndPathCoverage` to `false` explicitly + apply this bugfix.

Thank you!