### PR TITLE
Exclude unnecessary files from the dist files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+/.github               export-ignore
+/docs                  export-ignore
+/features              export-ignore
+/tests                 export-ignore
+.gitattributes         export-ignore
+.gitignore             export-ignore
+.php-cs-fixer.dist.php export-ignore
+.readthedocs.yaml      export-ignore
+.scrutinizer.yml       export-ignore
+behat.yml.dist         export-ignore
+phpunit.xml.dist       export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,4 @@
 /.github               export-ignore
-/docs                  export-ignore
 /features              export-ignore
 /tests                 export-ignore
 .gitattributes         export-ignore


### PR DESCRIPTION
Original motivation for this PR is that our CI detects requirements.txt from our vendor folder that you are shipping and then unnecessarily runs python scanning. We can as well exclude other files.