### PR TITLE
Use realpath for excluding files

### DIFF
--- a/src/Extension.php
+++ b/src/Extension.php
@@ -34,6 +34,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 use function sprintf;
 use function sys_get_temp_dir;
+use function realpath;
 
 class Extension implements ExtensionInterface
 {
@@ -218,7 +219,7 @@ class Extension implements ExtensionInterface
 
         foreach ($filterConfig['include']['directories'] as $directoryToInclude => $details) {
             foreach ((new FileIteratorFacade())->getFilesAsArray($directoryToInclude, $details['suffix'], $details['prefix']) as $fileToInclude) {
-                $files[$fileToInclude] = $fileToInclude;
+                $files[realpath($fileToInclude)] = realpath($fileToInclude);
             }
         }
 
@@ -233,7 +234,7 @@ class Extension implements ExtensionInterface
         }
 
         foreach ($filterConfig['exclude']['files'] as $fileToExclude) {
-            unset($files[$fileToExclude]);
+            unset($files[realpath($fileToExclude)]);
         }
 
         foreach ($files as $file) {


### PR DESCRIPTION
According to the documentation it should be possible to exclude file using relative paths. This is however not the case as the `$files` array is indexed using realpaths and unset instruction takes the argument as-is. This PR uses realpath also for unsetting the previously included file.