### PR TITLE
Use stderr for outputing warnings instead of stdout

### DIFF
--- a/src/Extension.php
+++ b/src/Extension.php
@@ -23,6 +23,7 @@ use SebastianBergmann\FileIterator\Facade as FileIteratorFacade;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
@@ -185,6 +186,10 @@ class Extension implements ExtensionInterface
 
         /** @var OutputInterface $output */
         $output = $container->get(CliExtension::OUTPUT_ID);
+
+        if ($output instanceof ConsoleOutputInterface) {
+            $output = $output->getErrorOutput();
+        }
 
         $filterConfig = $container->getParameter('behat.code_coverage.config.filter');
         $branchPathConfig = $container->getParameter('behat.code_coverage.config.branchAndPathCoverage');


### PR DESCRIPTION
This fixes phpstorm integration, which cannot currrently correctly detect behat version because of output that's mixed with the output from this extension.

![image](https://github.com/user-attachments/assets/6d1f9713-70eb-41dd-b2e2-9a3c8f786500)

I even created jetbrains issue but it was difficult to properly formulate the issue at the time https://youtrack.jetbrains.com/issue/WI-76429

In the end doing the fix here would be much easier. I've tested this and it fixes the integration.