### PR TITLE
chore: remove missing driver warning with --no-coverage

### DIFF
--- a/src/Extension.php
+++ b/src/Extension.php
@@ -204,7 +204,9 @@ class Extension implements ExtensionInterface
             $codeCoverageDefinition->setFactory([new Reference(self::class), 'initCodeCoverage']);
             $codeCoverageDefinition->setArguments([$filterDefinition, $filterConfig, $branchPathConfig, $cacheDir, $output]);
         } catch (NoCodeCoverageDriverAvailableException|XdebugNotEnabledException|XdebugNotAvailableException $e) {
-            $output->writeln("<comment>No code coverage driver is available. {$e->getMessage()}</comment>");
+            if (!$input->hasParameterOption('--no-coverage')) {
+                $output->writeln("<comment>No code coverage driver is available. {$e->getMessage()}</comment>");
+            }
             $canCollectCodeCoverage = false;
         }
 


### PR DESCRIPTION
Currently, a warning is displayed every single time we run behat tests without `XDEBUG_MODE=coverage`, even with `--no-coverage` passed.

Some tools (phpstorm) display outputted warnings with an alert icon, whereas the behavior seams to be correct here:  `--no-coverage` should mean `I don't want any alert about coverage neither`.

![image](https://github.com/user-attachments/assets/3661091c-87cc-4d1a-ad9d-b988ff22187d)
