### PR TITLE
Support --no-coverage and --profile=coverage

### DIFF
--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -105,11 +105,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.15"
+version = "3.13"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
 ]
 
 [[package]]
@@ -412,9 +412,9 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.7.0"
+version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
 ]

--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -105,11 +105,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]
@@ -412,9 +412,9 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -225,7 +225,9 @@ class Extension implements ExtensionInterface
         $branchPathConfig = $container->getParameter('behat.code_coverage.config.branchAndPathCoverage');
         $cacheDir = $container->getParameter('behat.code_coverage.config.cache');
 
-        $canCollectCodeCoverage = !$input->hasParameterOption('--no-coverage');
+        $canCollectCodeCoverage = !$input->hasParameterOption('--no-coverage')
+            || $input->getParameterOption('--profile') === 'coverage';
+
         if ($canCollectCodeCoverage) {
             try {
                 $this->initCodeCoverage(new Filter(), $filterConfig, $branchPathConfig, $cacheDir, $output);
@@ -280,7 +282,7 @@ class Extension implements ExtensionInterface
         if ($branchPathConfig !== false) {
             try {
                 $driver = $selector->forLineAndPathCoverage($filter);
-            } catch (NoSupportedDriverAvailableException|NoCodeCoverageDriverWithPathCoverageSupportAvailableException|XdebugNotAvailableException|XdebugNotEnabledException $e) {
+            } catch (NoSupportedDriverAvailableException|NoCodeCoverageDriverWithPathCoverageSupportAvailableException|XdebugNotAvailableException|XdebugNotEnabledException) {
                 // fallback driver is already set
                 if ($branchPathConfig === true) { // only warn if explicitly enabled
                     $output->writeln(sprintf('<info>%s does not support collecting branch and path data</info>', $driver->nameAndVersion()));

--- a/src/Service/ReportService.php
+++ b/src/Service/ReportService.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 namespace DVDoug\Behat\CodeCoverage\Service;
 
 use Composer\InstalledVersions;
+use Composer\Semver\VersionParser;
 use SebastianBergmann\CodeCoverage\CodeCoverage;
 use SebastianBergmann\CodeCoverage\Report\Clover;
 use SebastianBergmann\CodeCoverage\Report\Cobertura;
@@ -41,7 +42,7 @@ class ReportService
      */
     public function generateReport(CodeCoverage $coverage): void
     {
-        if (InstalledVersions::satisfies(new \Composer\Semver\VersionParser(), 'phpunit/php-code-coverage', '<14')) {
+        if (InstalledVersions::satisfies(new VersionParser(), 'phpunit/php-code-coverage', '<14')) {
             $this->generateReportPreV14($coverage);
 
             return;
@@ -153,10 +154,23 @@ class ReportService
                     );
                     $colors = Colors::from(
                         $config['colors']['successLow'],
+                        $config['colors']['successLowDark'],
                         $config['colors']['successMedium'],
+                        $config['colors']['successMediumDark'],
                         $config['colors']['successHigh'],
+                        $config['colors']['successHighDark'],
+                        $config['colors']['successBar'],
+                        $config['colors']['successBarDark'],
                         $config['colors']['warning'],
+                        $config['colors']['warningDark'],
+                        $config['colors']['warningBar'],
+                        $config['colors']['warningBarDark'],
                         $config['colors']['danger'],
+                        $config['colors']['dangerDark'],
+                        $config['colors']['dangerBar'],
+                        $config['colors']['dangerBarDark'],
+                        $config['colors']['breadcrumbs'],
+                        $config['colors']['breadcrumbsDark'],
                     );
                     if ($config['customCSSFile']) {
                         $customCss = CustomCssFile::from($config['customCSSFile']);

--- a/src/Subscriber/EventSubscriber.php
+++ b/src/Subscriber/EventSubscriber.php
@@ -54,7 +54,7 @@ class EventSubscriber implements EventSubscriberInterface
     /**
      * After Scenario/Outline Example hook.
      */
-    public function afterScenario(ScenarioTested $event): void
+    public function afterScenario(): void
     {
         if (!$this->coverage) {
             return;
@@ -66,7 +66,7 @@ class EventSubscriber implements EventSubscriberInterface
     /**
      * After Exercise hook.
      */
-    public function afterExercise(ExerciseCompleted $event): void
+    public function afterExercise(): void
     {
         if (!$this->coverage) {
             return;


### PR DESCRIPTION
## Summary
- `Extension`: coverage collection is now disabled by the legacy `--no-coverage` flag, or enabled by an explicit `--profile=coverage`, so both older Behat setups (using `--no-coverage`) and newer profile-based setups keep working.
- `ReportService`: import `Composer\Semver\VersionParser` instead of the inline FQCN, and pass through the additional `*Dark`/`*Bar`/`breadcrumbs*` color config keys expected by the current `phpunit/php-code-coverage` HTML report (`Colors::from()`).
- `EventSubscriber`: drop unused event parameters from `afterScenario`/`afterExercise`.

## Test plan
- [x] Manual check: running with `--no-coverage` still skips coverage
- [x] Manual check: running with `--profile=coverage` (and no `--no-coverage`) collects coverage